### PR TITLE
Webhook support

### DIFF
--- a/src/TelegramBot/bot.cr
+++ b/src/TelegramBot/bot.cr
@@ -115,15 +115,12 @@ module TelegramBot
       if response.status_code == 200
         json = JSON.parse(response.body)
         if json["ok"]
-          logger.debug(json)
           return json["result"]
         else
-          logger.warn(json)
-          return JSON.parse %({})
+          raise json["error"].as_s
         end
       else
-        logger.warn(response)
-        return JSON.parse %({})
+        raise "Error #{response.status_code} in call to Telegram API: #{response.body}"
       end
     end
 

--- a/src/TelegramBot/bot.cr
+++ b/src/TelegramBot/bot.cr
@@ -1,5 +1,6 @@
 require "http/client"
 require "json"
+require "logger"
 require "./helper.cr"
 require "./types/inline/*"
 require "./types/*"
@@ -58,9 +59,13 @@ module TelegramBot
             end
           end
         rescue ex
-          pp ex
+          logger.error(ex)
         end
       end
+    end
+
+    protected def logger : Logger
+      @logger ||= Logger.new(STDOUT).tap { |l| l.level = Logger::DEBUG }
     end
 
     private def allowed_user?(msg) : Bool
@@ -110,14 +115,14 @@ module TelegramBot
       if response.status_code == 200
         json = JSON.parse(response.body)
         if json["ok"]
+          logger.debug(json)
           return json["result"]
         else
-          pp json
+          logger.warn(json)
           return JSON.parse %({})
         end
       else
-        pp response.status_code
-        p response.body
+        logger.warn(response)
         return JSON.parse %({})
       end
     end

--- a/src/TelegramBot/bot.cr
+++ b/src/TelegramBot/bot.cr
@@ -6,9 +6,14 @@ require "./types/inline/*"
 require "./types/*"
 
 require "./http_client_multipart.cr"
+require "./http_client.cr"
+require "./response_client.cr"
 
 module TelegramBot
   abstract class Bot
+
+    @http_context : HTTP::Server::Context?
+
     # handle messages
     # return: true if the message is handled successfully
     #         this can be useful for overwrited handlers
@@ -44,23 +49,50 @@ module TelegramBot
         begin
           updates = get_updates
           updates.each do |u|
-            if msg = u.message
-              next if !allowed_user?(msg)
-              handle msg
-            elsif query = u.inline_query
-              next if !allowed_user?(query)
-              handle query
-            elsif choosen = u.choosen_inline_result
-              next if !allowed_user?(choosen)
-              handle choosen
-            elsif callback_query = u.callback_query
-              next if !allowed_user?(callback_query)
-              handle callback_query
-            end
+            handle_update(u)
           end
         rescue ex
           logger.error(ex)
         end
+      end
+    end
+
+    def serve(bind_address : String = "127.0.0.1", bind_port : Int32 = 80, ssl_certificate_path : String | Nil = nil, ssl_key_path : String | Nil = nil)
+      server = HTTP::Server.new(bind_address, bind_port) do |context|
+        begin
+          @http_context = context
+          handle_update(TelegramBot::Update.from_json(context.request.body.not_nil!))
+        rescue ex
+          logger.error(ex)
+        ensure
+          @http_context = nil
+        end
+      end
+
+      if ssl_certificate_path && ssl_key_path
+        ssl = OpenSSL::SSL::Context.new
+        ssl.certificate_chain = ssl_certificate_path.not_nil!
+        ssl.private_key = ssl_key_path.not_nil!
+        server.ssl = ssl
+      end
+
+      logger.info("Listening for Telegram requests in #{bind_address}:#{bind_port}#{" with ssl" if server.ssl}")
+      server.listen
+    end
+
+    def handle_update(u)
+      if msg = u.message
+        return if !allowed_user?(msg)
+        handle msg
+      elsif query = u.inline_query
+        return if !allowed_user?(query)
+        handle query
+      elsif choosen = u.choosen_inline_result
+        return if !allowed_user?(choosen)
+        handle choosen
+      elsif callback_query = u.callback_query
+        return if !allowed_user?(callback_query)
+        handle callback_query
       end
     end
 
@@ -101,17 +133,28 @@ module TelegramBot
       return true
     end
 
-    protected def request(method : String, params : Hash = {} of String => Object)
-      url = "https://api.telegram.org/bot#{@token}/#{method}"
-      response = if params.values.any?(&.is_a?(::File))
-        HTTP::Client.post_multipart url, params
+    protected def request(method : String, force_http : Bool = false, params : Hash = {} of String => Object)
+      client = if !force_http && (context = @http_context)
+        ResponseClient.new(context.not_nil!.response)
+      else
+        HttpClient.new(@token)
+      end
+
+      response = if params.values.any?(&.is_a?(::IO::FileDescriptor))
+        multipart_params = HTTP::Client::MultipartBody.new(params)
+        client.post_multipart method, multipart_params
       elsif params.any?
         stringified_params = params.reduce(Hash(String, String).new) { |h,k,v| h[k] = v.to_s; h }
-        HTTP::Client.post_form url, stringified_params
+        client.post_form method, stringified_params
       else
-        HTTP::Client.post url
+        client.post method
       end
-      
+
+      return nil if response.nil?
+      handle_http_response(response)
+    end
+
+    protected def handle_http_response(response)
       if response.status_code == 200
         json = JSON.parse(response.body)
         if json["ok"]
@@ -125,11 +168,11 @@ module TelegramBot
     end
 
     def get_me
-      request "getMe"
+      request "getMe", force_http: true
     end
 
     private def get_updates(offset = @nextoffset, limit : Int32? = nil, timeout : Int32? = @updates_timeout)
-      data = request "getUpdates", {"offset": "#{offset}"}
+      data = request("getUpdates", force_http: true, params: {"offset": "#{offset}"}).not_nil!
 
       r = [] of Update
       data.each do |json|
@@ -143,7 +186,15 @@ module TelegramBot
     end
 
     macro def_request(name, *args)
-        request {{name}}, {
+        request {{name}}, force_http: false, params: {
+          {% for arg in args %}
+            {{arg.stringify}} : {{arg.id}},
+          {% end %}
+        }
+    end
+
+    macro def_force_request(name, *args)
+        request {{name}}, force_http: true, params: {
           {% for arg in args %}
             {{arg.stringify}} : {{arg.id}},
           {% end %}
@@ -158,22 +209,21 @@ module TelegramBot
                      disable_web_page_preview : Bool? = nil,
                      disable_notification : Bool? = nil,
                      reply_to_message_id : Int32? = nil,
-                     reply_markup : ReplyMarkup = nil) : Message
+                     reply_markup : ReplyMarkup = nil) : Message?
       if reply_markup
         reply_markup = reply_markup.to_json
       end
       res = def_request "sendMessage", chat_id, text, parse_mode, disable_notification, disable_web_page_preview, reply_to_message_id, reply_markup
-      # puts res.to_json
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def reply(message : Message, text : String) : Message
       send_message(message.chat.id, text, reply_to_message_id: message.message_id)
     end
 
-    def forward_message(chat_id : Int32 | String, from_chat_id : Int32 | String, message_id : Int32, disable_notification : Bool? = nil)
+    def forward_message(chat_id : Int32 | String, from_chat_id : Int32 | String, message_id : Int32, disable_notification : Bool? = nil) : Message?
       res = def_request "forwardMessage", chat_id, from_chat_id, message_id, disable_notification
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     # photo file or file id
@@ -182,9 +232,9 @@ module TelegramBot
                    caption : String? = nil,
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
-                   reply_markup : ReplyMarkup = nil)
+                   reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendPhoto", chat_id, photo, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_audio(chat_id : Int32 | String,
@@ -194,9 +244,9 @@ module TelegramBot
                    title : String? = nil,
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
-                   reply_markup : ReplyMarkup = nil)
+                   reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendPhoto", chat_id, audio, duration, performer, title, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_document(chat_id : Int32 | String,
@@ -204,18 +254,18 @@ module TelegramBot
                       caption : String? = nil,
                       disable_notification : Bool? = nil,
                       reply_to_message_id : Int32? = nil,
-                      reply_markup : ReplyMarkup = nil)
+                      reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendDocument", chat_id, document, caption, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_sticker(chat_id : Int32 | String,
                      sticker : ::File | String,
                      disable_notification : Bool? = nil,
                      reply_to_message_id : Int32? = nil,
-                     reply_markup : ReplyMarkup = nil)
+                     reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendSticker", chat_id, sticker, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_video(chat_id : Int32 | String,
@@ -226,9 +276,9 @@ module TelegramBot
                    caption : String? = nil,
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
-                   reply_markup : ReplyMarkup = nil)
+                   reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendVideo", chat_id, video, duration, width, height, disable_notification, caption, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_voice(chat_id : Int32 | String,
@@ -236,9 +286,9 @@ module TelegramBot
                    duration : Int32? = nil,
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
-                   reply_markup : ReplyMarkup = nil)
+                   reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendVoice", chat_id, voice, duration, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_location(chat_id : Int32 | String,
@@ -246,9 +296,9 @@ module TelegramBot
                       longitude : Float,
                       disable_notification : Bool? = nil,
                       reply_to_message_id : Int32? = nil,
-                      reply_markup : ReplyMarkup = nil)
+                      reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendLocation", chat_id, latitude, longitude, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_venue(chat_id : Int32 | String,
@@ -259,9 +309,9 @@ module TelegramBot
                    forsquare_id : String? = nil,
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
-                   reply_markup : ReplyMarkup = nil)
+                   reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendVenue", chat_id, latitude, longitude, title, address, forsquare_id, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_contact(chat_id : Int32 | String,
@@ -269,40 +319,40 @@ module TelegramBot
                      first_name : String,
                      last_name : String? = nil,
                      reply_to_message_id : Int32? = nil,
-                     reply_markup : ReplyMarkup = nil)
+                     reply_markup : ReplyMarkup = nil) : Message?
       res = def_request "sendContact", chat_id, phone_number, first_name, last_name, disable_notification, reply_to_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def send_chat_action(chat_id : Int32 | String,
                          action : String)
-      res = def_request "sendChatAction", chat_id, action
+      def_request "sendChatAction", chat_id, action
     end
 
     def get_user_profile_photos(user_id : Int32,
                                 offset : Int32? = nil,
                                 limit : Int32? = nil)
-      res = def_request "getUserProfilePhotos", user_id, offset, limit
-      UserProfilePhotos.from_json res.to_json
+      res = def_force_request "getUserProfilePhotos", user_id, offset, limit
+      UserProfilePhotos.from_json res.not_nil!.to_json
     end
 
     def kick_chat_member(chat_id : Int32 | String,
                          user_id : Int32)
       res = def_request "kickChatMember", chat_id, user_id
-      res.as_bool
+      res.as_bool if res
     end
 
     def unban_chat_member(chat_id : Int32 | String,
                           user_id : Int32)
       res = def_request "unbanChatMember", chat_id, user_id
-      res.as_bool
+      res.as_bool if res
     end
 
     def answer_callback_query(callback_query_id : String,
                               text : String? = nil,
                               show_alert : Bool? = nil)
       res = def_request "answerCallbackQuery", callback_query_id, text, show_alert
-      res.as_bool
+      res.as_bool if res
     end
 
     def edit_message_text(chat_id : Int32 | String | Nil = nil,
@@ -311,29 +361,29 @@ module TelegramBot
                           text : String? = nil,
                           parse_mode : String? = nil,
                           disable_web_page_preview : Bool? = nil,
-                          reply_markup : InlineKeyboardMarkup? = nil)
+                          reply_markup : InlineKeyboardMarkup? = nil) : Message?
       reply_markup = reply_markup.to_json
       res = def_request "editMessageText", chat_id, message_id, inline_message_id, text, parse_mode, disable_web_page_preview, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def edit_message_caption(chat_id : Int32 | String | Nil = nil,
                              message_id : Int32? = nil,
                              inline_message_id : String = nil,
                              caption : String? = nil,
-                             reply_markup : InlineKeyboardMarkup? = nil)
+                             reply_markup : InlineKeyboardMarkup? = nil) : Message?
       reply_markup = reply_markup.to_json
       res = def_request "editMessageCaption", chat_id, message_id, inline_message_id, caption, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def edit_message_reply_markup(chat_id : Int32 | String | Nil = nil,
                                   message_id : Int32? = nil,
                                   inline_message_id : String = nil,
-                                  reply_markup : InlineKeyboardMarkup? = nil)
+                                  reply_markup : InlineKeyboardMarkup? = nil) : Message?
       reply_markup = reply_markup.to_json
       res = def_request "editMessageReplyMarkup", chat_id, message_id, inline_message_id, reply_markup
-      Message.from_json res.to_json
+      Message.from_json res.to_json if res
     end
 
     def answer_inline_query(inline_query_id : String,
@@ -342,16 +392,15 @@ module TelegramBot
                             is_personal : Bool? = nil,
                             next_offset : String? = nil,
                             switch_pm_text : String? = nil,
-                            switch_pm_parameter : String? = nil) : Bool
+                            switch_pm_parameter : String? = nil) : Bool?
       # results   Array of InlineQueryResult  Yes   A JSON-serialized array of results for the inline query
       results = "[" + results.join(", ") { |a| a.to_json } + "]"
       res = def_request "answerInlineQuery", inline_query_id, cache_time, is_personal, next_offset, results, switch_pm_text, switch_pm_parameter
-
-      return res.as_bool
+      res.as_bool if res
     end
 
     def get_file(file_id : String) : File
-      res = def_request "getFile", file_id
+      res = def_force_request "getFile", file_id
       File.from_json(res.to_json)
     end
 
@@ -366,5 +415,14 @@ module TelegramBot
     def download(file_path : String)
       HTTP::Client.get("https://api.telegram.org/file/bot#{@token}/#{file_path}").body
     end
+
+    def set_webhook(url : String, certificate : ::File | String | Nil = nil)
+      multipart_params = HTTP::Client::MultipartBody.new({"url" => url})
+      multipart_params.add_file("certificate", certificate, filename: "cert.pem") if certificate
+      logger.info("Setting webhook to '#{url}'#{" with certificate" if certificate}")
+      response = HttpClient.new(@token).post_multipart "setWebhook", multipart_params
+      handle_http_response(response)
+    end
+
   end
 end

--- a/src/TelegramBot/bot.cr
+++ b/src/TelegramBot/bot.cr
@@ -33,7 +33,7 @@ module TelegramBot
     # @whitelist
     # @blacklist
     # @users list of users for private mode
-    def initialize(@name : String, @token : String, @whitelist : Array(String)? = nil, @blacklist : Array(String)? = nil)
+    def initialize(@name : String, @token : String, @whitelist : Array(String)? = nil, @blacklist : Array(String)? = nil, @updates_timeout : Int32 = nil)
       @nextoffset = 0
     end
 
@@ -128,7 +128,7 @@ module TelegramBot
       request "getMe"
     end
 
-    private def get_updates(offset = @nextoffset, limit : Int32? = nil, timeout : Int32? = nil)
+    private def get_updates(offset = @nextoffset, limit : Int32? = nil, timeout : Int32? = @updates_timeout)
       data = request "getUpdates", {"offset": "#{offset}"}
 
       r = [] of Update

--- a/src/TelegramBot/cmd_handler.cr
+++ b/src/TelegramBot/cmd_handler.cr
@@ -37,7 +37,7 @@ module TelegramBot
             cmd = parts[0]
           end
 
-          pp cmd
+          logger.info(cmd)
           call cmd, message
           return true
         else
@@ -48,8 +48,7 @@ module TelegramBot
         return false
       end
     rescue e
-      puts "ERROR"
-      pp e.message
+      logger.error(e)
       # can't handle this
       return false
     end

--- a/src/TelegramBot/http_client.cr
+++ b/src/TelegramBot/http_client.cr
@@ -1,0 +1,28 @@
+require "http/client"
+
+module TelegramBot
+
+  class HttpClient
+
+    def initialize(@token : String)
+    end
+
+    def post(method : String)
+      HTTP::Client.post(url_for(method))
+    end
+
+    def post_form(method : String, params : Hash)
+      HTTP::Client.post_form(url_for(method), params)
+    end
+
+    def post_multipart(method : String, params)
+      HTTP::Client.post_multipart(url_for(method), params)
+    end
+
+    protected def url_for(method) : String
+      "https://api.telegram.org/bot#{@token}/#{method}"
+    end
+
+  end
+
+end

--- a/src/TelegramBot/http_client_multipart.cr
+++ b/src/TelegramBot/http_client_multipart.cr
@@ -35,7 +35,7 @@ class HTTP::Client
     end
 
     def add_file(name : String, file : ::File, mime_type : String = "")
-      @body += "\r\n--" + @boundary + "\r\n"
+      @body += "--" + @boundary + "\r\n"
       @body += "Content-Disposition: form-data; name=\"#{name}\"; filename=\"#{file.path}\"\r\n"
       if mime_type
         @body += "Content-Type: #{mime_type}\r\n"

--- a/src/TelegramBot/http_client_multipart.cr
+++ b/src/TelegramBot/http_client_multipart.cr
@@ -1,13 +1,24 @@
 require "http/client"
 
 class HTTP::Client
-  def self.post_multipart(url : String | URI, headers : HTTP::Headers, parts = MultipartBody) : HTTP::Client::Response
+  def self.post_multipart(url : String | URI, parts : MultipartBody, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+    headers ||= HTTP::Headers.new
     headers["Content-Type"] = "multipart/form-data; boundary=#{parts.boundary}"
-    # if !url.includes?("getUpdate")
-    # r = Request.new "POST", url, headers, parts.bodyg
-    # r.to_io(STDOUT)
-    # end
     post url, headers, parts.bodyg
+  end
+
+  def self.post_multipart(url : String | URI, params : Hash, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+    parts = HTTP::Client::MultipartBody.new
+    params.each do |k, v|
+      if v.nil?
+        next
+      elsif v.is_a?(::File)
+        parts.add_file(k, v)
+      else
+        parts.add_part(k, v.to_s)
+      end
+    end
+    post_multipart(url, parts, headers)
   end
 
   # ugly represation of multipart/from-data (works for now)

--- a/src/TelegramBot/http_client_multipart.cr
+++ b/src/TelegramBot/http_client_multipart.cr
@@ -1,42 +1,50 @@
 require "http/client"
 
 class HTTP::Client
-  def self.post_multipart(url : String | URI, parts : MultipartBody, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
-    headers ||= HTTP::Headers.new
-    headers["Content-Type"] = "multipart/form-data; boundary=#{parts.boundary}"
-    post url, headers, parts.bodyg
+  def self.post_multipart(url : String | URI, parts : MultipartBody | Hash, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+    exec(url) do |client, path|
+      client.post_multipart(path, parts, headers)
+    end
   end
 
-  def self.post_multipart(url : String | URI, params : Hash, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
-    parts = HTTP::Client::MultipartBody.new
-    params.each do |k, v|
-      if v.nil?
-        next
-      elsif v.is_a?(::File)
-        parts.add_file(k, v)
-      else
-        parts.add_part(k, v.to_s)
-      end
-    end
-    post_multipart(url, parts, headers)
+  def post_multipart(path, parts : MultipartBody, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+    headers ||= HTTP::Headers.new
+    headers["Content-Type"] = "multipart/form-data; boundary=#{parts.boundary}"
+    post path, headers, parts.bodyg
+  end
+
+  def post_multipart(path, params : Hash, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+    parts = HTTP::Client::MultipartBody.new(params)
+    post_multipart(path, parts, headers)
   end
 
   # ugly represation of multipart/from-data (works for now)
   class MultipartBody
     getter boundary
 
-    @boundary : String
+    @boundary : String = Random.rand(999999).to_s + Random.rand(999999).to_s + Random.rand(999999).to_s + Random.rand(999999).to_s
+    @body : String = ""
 
     def bodyg
       @body + "--" + @boundary + "--\r\n"
     end
 
     def initialize
-      @boundary = Random.rand(999999).to_s + Random.rand(999999).to_s + Random.rand(999999).to_s + Random.rand(999999).to_s
-      @body = ""
     end
 
-    def add_part(name : String, content : String, mime_type : String = "text/plain")
+    def initialize(params : Hash)
+      params.each do |k, v|
+        if v.nil?
+          next
+        elsif v.is_a?(::File)
+          add_file(k, v)
+        else
+          add_part(k, v.to_s)
+        end
+      end
+    end
+
+    def add_part(name : String, content : String, mime_type : String = nil)
       @body += "--" + @boundary + "\r\n"
       @body += "Content-Disposition: form-data; name=\"#{name}\"\r\n"
       if mime_type
@@ -45,20 +53,19 @@ class HTTP::Client
       @body += "\r\n" + content + "\r\n"
     end
 
-    def add_file(name : String, file : ::File, mime_type : String = "application/octet-stream")
+    def add_file(name : String, content : String, filename : String? = nil, mime_type : String = "application/octet-stream")
       @body += "--" + @boundary + "\r\n"
-      @body += "Content-Disposition: form-data; name=\"#{name}\"; filename=\"#{file.path}\"\r\n"
+      @body += "Content-Disposition: form-data; name=\"#{name}\"; filename=\"#{filename}\"\r\n"
       if mime_type
         @body += "Content-Type: #{mime_type}\r\n"
       end
 
-      size = file.size.to_i
-      content = String.new(size) do |buffer|
-        file.read Slice.new(buffer, size)
-        {size.to_i, 0}
-      end
-
       @body += "\r\n" + content + "\r\n"
+    end
+
+    def add_file(name : String, file : ::File | ::Tempfile, filename : String? = nil, mime_type : String = "application/octet-stream")
+      content = File.read(file.path)
+      add_file(name, content, filename || file.path, mime_type)
     end
   end
 end

--- a/src/TelegramBot/http_client_multipart.cr
+++ b/src/TelegramBot/http_client_multipart.cr
@@ -34,7 +34,7 @@ class HTTP::Client
       @body += "\r\n" + content + "\r\n"
     end
 
-    def add_file(name : String, file : ::File, mime_type : String = "")
+    def add_file(name : String, file : ::File, mime_type : String = "application/octet-stream")
       @body += "--" + @boundary + "\r\n"
       @body += "Content-Disposition: form-data; name=\"#{name}\"; filename=\"#{file.path}\"\r\n"
       if mime_type

--- a/src/TelegramBot/response_client.cr
+++ b/src/TelegramBot/response_client.cr
@@ -1,0 +1,32 @@
+module TelegramBot
+
+  class ResponseClient
+
+    def initialize(@response : HTTP::Server::Response)
+    end
+
+    def post(method : String)
+      post_form(method, {} of String => String)
+    end
+
+    def post_form(method : String, params : Hash(String, String))
+      body = HTTP::Params.build do |form_builder|
+        params.each { |key, value| form_builder.add key, value }
+        form_builder.add "method", method
+      end
+
+      @response.content_type = "application/x-www-form-urlencoded"
+      @response.print(body)
+      nil
+    end
+
+    def post_multipart(method : String, multipart_body : HTTP::Client::MultipartBody)
+      multipart_body.add_part("method", method)
+      @response.content_type = "multipart/form-data; boundary=#{multipart_body.boundary}"
+      @response.print(multipart_body.bodyg)
+      nil
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR, built on top of #4 and #5, adds support for the Telegram webhook updates. The bot can now be started either by polling or by serving.