### PR TITLE
Support for keyboard buttons requesting contact and location

### DIFF
--- a/spec/keyboard_markup_spec.cr
+++ b/spec/keyboard_markup_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+
+describe TelegramBot::ReplyKeyboardMarkup do
+  it "can be built with KeyboardButton objects" do
+    buttons = [[
+      TelegramBot::KeyboardButton.new("Button 1", request_contact: false, request_location: true),
+      TelegramBot::KeyboardButton.new("Button 2", request_contact: true, request_location: false),
+    ]]
+
+    markup_json = TelegramBot::ReplyKeyboardMarkup.new(buttons).to_json
+
+    JSON.parse(markup_json).should eq({"keyboard" => [
+      [
+        {"text" => "Button 1", "request_contact" => false, "request_location" => true},
+        {"text" => "Button 2", "request_contact" => true, "request_location" => false},
+      ],
+    ]})
+  end
+
+  it "can be built with text only if other flags are unnecesary" do
+    buttons = [["Button 1", "Button 2"]]
+
+    markup_json = TelegramBot::ReplyKeyboardMarkup.new(buttons).to_json
+    JSON.parse(markup_json).should eq({"keyboard" => [[{"text" => "Button 1"}, {"text" => "Button 2"}]]})
+  end
+end

--- a/src/TelegramBot/types/reply_keyboard_markup.cr
+++ b/src/TelegramBot/types/reply_keyboard_markup.cr
@@ -1,15 +1,33 @@
 require "json"
 
 module TelegramBot
+  class KeyboardButton
+    FIELDS = {
+      text:             {type: String, nilable: false},
+      request_contact:  {type: Bool, nilable: true},
+      request_location: {type: Bool, nilable: true},
+    }
+
+    JSON.mapping({{FIELDS}})
+    initializer_for({{FIELDS}})
+  end
+
   class ReplyKeyboardMarkup
     FIELDS = {
-      keyboard:          Array(Array(String)),
+      keyboard:          Array(Array(KeyboardButton)),
       resize_keyboard:   {type: Bool, nilable: true},
       one_time_keyboard: {type: Bool, nilable: true},
       selective:         {type: Bool, nilable: true},
     }
 
     JSON.mapping({{FIELDS}})
+
     initializer_for({{FIELDS}})
+
+    # Alternative constructor that allows to build markup object with text-only buttons
+    def initialize(keyboard : Array(Array(String)), resize_keyboard : Bool? = nil, one_time_keyboard : Bool? = nil, selective : Bool? = nil)
+      buttons = keyboard.map { |row| row.map { |text| KeyboardButton.new(text) } }
+      initialize(buttons, resize_keyboard, one_time_keyboard, selective)
+    end
   end
 end


### PR DESCRIPTION
Use the KeyboardButton object for defining keyboard markups, to allow buttons that request user location and contact (see https://core.telegram.org/bots/api#keyboardbutton).

A second constructor is provided in ReplyKeyboardMarkup for backwards compatibility, that allows creating buttons with plain Strings.