### PR TITLE
Correctly handle multiple requests or responses in webhook mode

### DIFF
--- a/src/TelegramBot/fiber.cr
+++ b/src/TelegramBot/fiber.cr
@@ -1,0 +1,7 @@
+require "http/server"
+
+class Fiber
+
+  property telegram_bot_server_http_context : HTTP::Server::Context?
+
+end

--- a/src/TelegramBot/response_client.cr
+++ b/src/TelegramBot/response_client.cr
@@ -17,6 +17,7 @@ module TelegramBot
 
       @response.content_type = "application/x-www-form-urlencoded"
       @response.print(body)
+      @response.close
       nil
     end
 
@@ -24,6 +25,7 @@ module TelegramBot
       multipart_body.add_part("method", method)
       @response.content_type = "multipart/form-data; boundary=#{multipart_body.boundary}"
       @response.print(multipart_body.bodyg)
+      @response.close
       nil
     end
 


### PR DESCRIPTION
This PR moves the HTTP context stored for the duration of the request to a fiber-local var. Previously it was an instance var, which caused all fibers working simultaneously to work on the same context.

Also clears out the context right after the first response was sent, to speed up processing, and support invoking multiple methods as part of the same response (the first one is sent as a response, the others are sent as regular HTTP requests).